### PR TITLE
Updated to TechnoLib 2.1.0 to fix the jiggly bug

### DIFF
--- a/LearnBot/src/main/java/org/firstinspires/ftc/learnbot/opmodes/auto/Basic.java
+++ b/LearnBot/src/main/java/org/firstinspires/ftc/learnbot/opmodes/auto/Basic.java
@@ -3,12 +3,16 @@ package org.firstinspires.ftc.learnbot.opmodes.auto;
 import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.acmerobotics.roadrunner.geometry.Vector2d;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.technototes.library.command.CommandScheduler;
 import com.technototes.library.command.SequentialCommandGroup;
 import com.technototes.library.command.WaitCommand;
 import com.technototes.library.logger.Loggable;
 import com.technototes.library.structure.CommandOpMode;
+import com.technototes.path.command.TrajectorySequenceCommand;
+import com.technototes.path.geometry.ConfigurablePoseD;
+
 import org.firstinspires.ftc.learnbot.Hardware;
 import org.firstinspires.ftc.learnbot.Robot;
 import org.firstinspires.ftc.learnbot.Setup;
@@ -26,7 +30,7 @@ import org.firstinspires.ftc.learnbot.Setup;
 @SuppressWarnings("unused")
 public class Basic extends CommandOpMode implements Loggable {
 
-    public static int AUTO_TIME = 25;
+    public static int AUTO_TIME = 1;
     public Hardware hardware;
     public Robot robot;
 
@@ -36,14 +40,22 @@ public class Basic extends CommandOpMode implements Loggable {
         hardware = new Hardware(hardwareMap);
         robot = new Robot(hardware);
         CommandScheduler.scheduleForState(
-            new SequentialCommandGroup(
-                // new TurboCommand(robot.drivebaseSubsystem),
-                // new StartSpinningCmd(robot.spinner),
-                new WaitCommand(AUTO_TIME),
-                // new StopSpinningCmd(robot.spinner),
-                CommandScheduler::terminateOpMode
-            ),
-            CommandOpMode.OpModeState.RUN
+                new SequentialCommandGroup(
+                        new TrajectorySequenceCommand(robot.drivebaseSubsystem, b ->
+                                b.apply(new ConfigurablePoseD(0, 0, 0).toPose())
+                                        .lineTo(new Vector2d(5, 5))
+                                        .build()),
+                        // new TurboCommand(robot.drivebaseSubsystem),
+                        // new StartSpinningCmd(robot.spinner),
+                        new WaitCommand(AUTO_TIME),
+                        new TrajectorySequenceCommand(robot.drivebaseSubsystem, b ->
+                                b.apply(new ConfigurablePoseD(5, 5, 0).toPose())
+                                        .lineTo(new Vector2d(0, 0))
+                                        .build()),
+                        // new StopSpinningCmd(robot.spinner),
+                        CommandScheduler::terminateOpMode
+                ),
+                CommandOpMode.OpModeState.RUN
         );
     }
 }

--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -30,7 +30,7 @@ dependencies {
     // Freik: 16750/20403 external dependencies:
     // TechnoLib: This should be commented out to use a local source copy
     //            'bun libflip' will also comment it out
-    implementation 'com.github.technototes:technolib:2.0.3' // FLIP: TechnoLibLocal
+    implementation 'com.github.technototes:technolib:2.1.0' // FLIP: TechnoLibLocal
 
     // RoadRunner - this is for pathing during autonomous
     implementation "com.acmerobotics.roadrunner:core:0.5.6"


### PR DESCRIPTION
I've confirmed before & after with this diff on ColinBot:
Prior (using TechnoLib 2.0.X) the first opmode you ran would work fine. If you then tried to run another opmode, things behaved strangely. If you started with an auto mode, and then tried a teleop, the bot would jerk toward the automode direction, while you could override it with the joystick. Vice versa was also true.

Not so anymore. Hurray! 