### PR TITLE
Made a robot 'prepForStart' method for uponStart opmode usage

### DIFF
--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/Robot.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/Robot.java
@@ -2,12 +2,14 @@ package org.firstinspires.ftc.sixteen750;
 
 import com.technototes.library.logger.Loggable;
 import com.technototes.library.util.Alliance;
+import org.firstinspires.ftc.sixteen750.commands.slides.HorizontalSlidesSequentials;
+import org.firstinspires.ftc.sixteen750.commands.slides.VerticalSlidesSequentials;
 import org.firstinspires.ftc.sixteen750.helpers.StartingPosition;
 import org.firstinspires.ftc.sixteen750.subsystems.DrivebaseSubsystem;
 import org.firstinspires.ftc.sixteen750.subsystems.HorizontalSlidesSubsystem;
-import org.firstinspires.ftc.sixteen750.subsystems.VerticalSlidesSubsystem;
 import org.firstinspires.ftc.sixteen750.subsystems.SafetySubsystem;
 import org.firstinspires.ftc.sixteen750.subsystems.TwoDeadWheelLocalizer;
+import org.firstinspires.ftc.sixteen750.subsystems.VerticalSlidesSubsystem;
 
 public class Robot implements Loggable {
 
@@ -48,9 +50,19 @@ public class Robot implements Loggable {
             }
         }
 
-        if (Setup.Connected.SAFETYSUBSYSTEM){
+        if (Setup.Connected.SAFETYSUBSYSTEM) {
             this.safetySubsystem = new SafetySubsystem(hw);
         }
+    }
 
+    public void prepForStart() {
+        if (Setup.Connected.HORIZONTALSLIDESUBSYSTEM) {
+            horizontalSlidesSubsystem.WristServoTransfer();
+            horizontalSlidesSubsystem.slidesRetract();
+            horizontalSlidesSubsystem.ClawChomp();
+        }
+        if (Setup.Connected.VERTICALSLIDESUBSYSTEM) {
+            verticalSlidesSubsystem.slidesDown();
+        }
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/commands/slides/HorizontalSlidesCommands.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/commands/slides/HorizontalSlidesCommands.java
@@ -1,7 +1,6 @@
 package org.firstinspires.ftc.sixteen750.commands.slides;
 
 import com.technototes.library.command.Command;
-
 import org.firstinspires.ftc.sixteen750.Robot;
 
 public class HorizontalSlidesCommands {
@@ -12,9 +11,11 @@ public class HorizontalSlidesCommands {
     public static Command horizontalExtend(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::slidesExtend);
     }
+
     public static Command horizontalRetract(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::slidesRetract);
     }
+
     public static Command horiSlideToggle(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::slideToggle);
     }
@@ -23,9 +24,11 @@ public class HorizontalSlidesCommands {
     public static Command clawChomp(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::ClawChomp);
     }
+
     public static Command clawOpen(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::ClawOpen);
     }
+
     public static Command clawToggle(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::clawToggle);
     }
@@ -34,24 +37,30 @@ public class HorizontalSlidesCommands {
     public static Command resetWristZero(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::resetWristZero);
     }
+
     public static Command wristToggle(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::wristToggle);
     }
+
     public static Command wristTransfer(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::WristServoTransfer);
     }
-    public static Command WristVertTransfer(Robot r) {
+
+    public static Command wristVertTransfer(Robot r) {
         return Command.create(
             r.horizontalSlidesSubsystem::WristVertTransfer,
             r.horizontalSlidesSubsystem
         );
     }
+
     public static Command wristPickup(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::WristServoPickup);
     }
+
     public static Command wristIncrement(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::WristServoIncrement);
     }
+
     public static Command wristDecrement(Robot r) {
         return Command.create(r.horizontalSlidesSubsystem::WristServoDecrement);
     }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/ChoiceTeleOp.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/ChoiceTeleOp.java
@@ -6,7 +6,6 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.technototes.library.command.CommandScheduler;
 import com.technototes.library.structure.CommandOpMode;
 import com.technototes.library.util.Alliance;
-
 import org.firstinspires.ftc.sixteen750.AutoConstants;
 import org.firstinspires.ftc.sixteen750.Hardware;
 import org.firstinspires.ftc.sixteen750.Robot;
@@ -52,11 +51,6 @@ public class ChoiceTeleOp extends CommandOpMode {
 
     @Override
     public void uponStart() {
-        if (Setup.Connected.HORIZONTALSLIDESUBSYSTEM) {
-            HorizontalSlidesSequentials.transferring(robot);
-        }
-        if (Setup.Connected.VERTICALSLIDESUBSYSTEM) {
-            VerticalSlidesSequentials.SlidesDown(robot);
-        }
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/DualTeleOp.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/DualTeleOp.java
@@ -50,11 +50,6 @@ public class DualTeleOp extends CommandOpMode {
 
     @Override
     public void uponStart() {
-        if (Setup.Connected.HORIZONTALSLIDESUBSYSTEM) {
-            HorizontalSlidesSequentials.transferring(robot);
-        }
-        if (Setup.Connected.VERTICALSLIDESUBSYSTEM) {
-            VerticalSlidesSequentials.SlidesDown(robot);
-        }
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/HorizTeleOp.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/HorizTeleOp.java
@@ -6,7 +6,6 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.technototes.library.command.CommandScheduler;
 import com.technototes.library.structure.CommandOpMode;
 import com.technototes.library.util.Alliance;
-
 import org.firstinspires.ftc.sixteen750.AutoConstants;
 import org.firstinspires.ftc.sixteen750.Hardware;
 import org.firstinspires.ftc.sixteen750.Robot;
@@ -53,11 +52,6 @@ public class HorizTeleOp extends CommandOpMode {
 
     @Override
     public void uponStart() {
-        if (Setup.Connected.HORIZONTALSLIDESUBSYSTEM) {
-            HorizontalSlidesSequentials.transferring(robot);
-        }
-        if (Setup.Connected.VERTICALSLIDESUBSYSTEM) {
-            VerticalSlidesSequentials.SlidesDown(robot);
-        }
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/VertTeleOp.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/VertTeleOp.java
@@ -53,11 +53,6 @@ public class VertTeleOp extends CommandOpMode {
 
     @Override
     public void uponStart() {
-        if (Setup.Connected.HORIZONTALSLIDESUBSYSTEM) {
-            HorizontalSlidesSequentials.transferring(robot);
-        }
-        if (Setup.Connected.VERTICALSLIDESUBSYSTEM) {
-            VerticalSlidesSequentials.SlidesDown(robot);
-        }
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/AutoTest.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/AutoTest.java
@@ -11,7 +11,6 @@ import org.firstinspires.ftc.sixteen750.AutoConstants;
 import org.firstinspires.ftc.sixteen750.Hardware;
 import org.firstinspires.ftc.sixteen750.Robot;
 import org.firstinspires.ftc.sixteen750.commands.auto.AutoTestingCommand;
-
 import org.firstinspires.ftc.sixteen750.controls.DriverController;
 import org.firstinspires.ftc.sixteen750.helpers.StartingPosition;
 
@@ -39,7 +38,6 @@ public class AutoTest extends CommandOpMode {
     }
 
     public void uponStart() {
-        robot.horizontalSlidesSubsystem.slidesRetract();
-        robot.horizontalSlidesSubsystem.WristServoTransfer();
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/ForwardBackward.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/ForwardBackward.java
@@ -42,6 +42,6 @@ public class ForwardBackward extends CommandOpMode {
     }
 
     public void uponStart() {
-        HorizontalSlidesSequentials.transferring(robot);
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/NetScoring.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/NetScoring.java
@@ -39,6 +39,6 @@ public class NetScoring extends CommandOpMode {
     }
 
     public void uponStart() {
-        HorizontalSlidesSequentials.transferring(robot);
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/Obs_Park.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/Obs_Park.java
@@ -37,6 +37,6 @@ public class Obs_Park extends CommandOpMode {
     }
 
     public void uponStart() {
-        HorizontalSlidesCommands.transferring(robot);
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/Obs_Push.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/Obs_Push.java
@@ -39,6 +39,6 @@ public class Obs_Push extends CommandOpMode {
     }
 
     public void uponStart() {
-        HorizontalSlidesCommands.transferring(robot);
+        robot.prepForStart();
     }
 }

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/Sideways.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/auto/Sideways.java
@@ -40,6 +40,6 @@ public class Sideways extends CommandOpMode {
     }
 
     public void uponStart() {
-        HorizontalSlidesCommands.transferring(robot);
+        robot.prepForStart();
     }
 }


### PR DESCRIPTION
There were a variety of different opmodes doing different things, so I made a single chunk of code (not a command: We aren't scheduling a command for start, we're directly running code), and fixed all the 16750 opmodes to call that new function in the `uponStart` method. @Magkhuu and @braelynandthefrogs  please take a look.